### PR TITLE
Update for recent breakage on OpenBSD

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,5 @@
+fixtures:
+  repositories:
+    stdlib: git://github.com/puppetlabs/puppetlabs-stdlib.git
+  symlinks:
+    pf: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,11 +3,12 @@ class pf (
   $pfctl          = '/sbin/pfctl',
   $tmpfile        = '/tmp/pf.conf',
   $conf           = '/etc/pf.conf',
-  $manage_service = true,
-  $service_ensure = true,
-  $service_enable = 'running',
-  $service_name   = 'pf',
-){
+  $manage_service = $pf::manage_service,
+  $service_enable = $pf::service_enable
+) inherits pf::params {
+
+  validate_bool($manage_service)
+  validate_bool($service_enable)
 
   if $template {
     file { $tmpfile:
@@ -26,10 +27,17 @@ class pf (
     }
 
     if $manage_service {
+      case $service_enable {
+        true: {
+          $service_ensure = 'running'
+        }
+        false: {
+          $service_ensure = 'stopped'
+        }
+      }
       service { 'pf':
         ensure  => $service_ensure,
         enable  => $service_enable,
-        name    => $service_name,
         require => File[$conf],
         before  => Exec['pfctl_update'],
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,12 @@
+class pf::params {
+  case $::kernel {
+    'OpenBSD': {
+      $manage_service = false
+      $service_enable = false
+    }
+    'FreeBSD': {
+      $manage_service = true
+      $service_enable = true
+    }
+  }
+}

--- a/spec/classes/pf_spec.rb
+++ b/spec/classes/pf_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'pf' do
+  context 'on OpenBSD' do
+    let(:facts) { {:kernel => 'OpenBSD'} }
+    it { should contain_class('pf') }
+
+  end
+
+  context 'on FreeBSD' do
+    let(:facts) { {:kernel => 'FreeBSD'} }
+    it { should contain_class('pf') }
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'rspec-puppet'
+
+fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
+
+RSpec.configure do |c|
+  c.module_path = File.join(fixture_path, 'modules')
+  c.manifest_dir = File.join(fixture_path, 'manifests')
+end


### PR DESCRIPTION
Recently, while improving the FreeBSD code, we broke the OpenBSD
functionality as we made assumptions about how services worked.  This
begins to split the logic necessary to work on both platforms.