### PR TITLE
Add pf::table define for class selection

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,10 @@
 fixtures:
   repositories:
-    stdlib: git://github.com/puppetlabs/puppetlabs-stdlib.git
+    stdlib:
+      repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+      ref: '4.4.0'
+    concat:
+      repo: "https://github.com/puppetlabs/puppetlabs-concat.git"
+      ref: '1.2.1'
   symlinks:
     pf: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ the majority of your firewalls, you can do so with just a change to a single
 firewall.  Obviously, how this structure is laid out and the usefulness of
 doing so will be dependent on the environment within which PF is deploy.
 
-### Dynamic rules with PuppetDB
+### Dynamic tables with PuppetDB
 
-Coming soon.
+Tables in PF hold groups of addresses for speedy lookup and simplified rulesets.  This combined with PuppetDB queries
+ makes for some interesting code.  You can use the `pf::table` defined type to specify a list of classes, who's IP 
+ addresses should be in a table.
+ 
+```Puppet
+pf::table {'ldap_servers':
+    class_list => ['profile::ldap::servers'],
+}
+```
+
+The above code will all a PF table entry to `/etc/pf.d/tables.pf` that you can simply include in your main 
+template with a simple `include "/etc/pf.d/tables.pf`.  Now you can use the `<ldap_servers>` table in your rule set 
+like you would with any other PF table.
+
+This table is populated by querying PuppetDB for all nodes who have the class `profile::ldap::servers` in their 
+catalog, and returning returning the values for `ipaddress` and `ipaddress6` from those nodes, and adding them to the
+table.  This doesn't work for all scenarious, for example, if the IP you want to add to a table is not in either of 
+those facts.
+ 
+I'm expecting more to come in this area.
+ 
+

--- a/lib/puppet/parser/functions/get_class_ip_list.rb
+++ b/lib/puppet/parser/functions/get_class_ip_list.rb
@@ -1,0 +1,38 @@
+module Puppet::Parser::Functions
+  newfunction(:get_class_ip_list,
+              :arity => 1,
+              :type => :rvalue) do |args|
+
+    class_list = args.shift
+
+    def self.normalize_class_names(names)
+      Array(names).each {|c|
+        # We need to get the class names in the correct capitalization
+        yield c.split('::').map {|i| i.capitalize }.join('::')
+      }
+    end
+
+    def self.get_fact_values(query, facts)
+      results = function_query_facts([query,facts])
+      facts.each {|f|
+        results.each_key.collect{|k,v|
+          if results[k].keys.include? f
+            yield results[k][f].strip
+          end
+        }
+      }
+    end
+
+    ip_list = []
+    self.normalize_class_names(class_list) {|c|
+      query = "Class[#{c}]"
+      facts = ['ipaddress', 'ipaddress6']
+      self.get_fact_values(query, facts) {|v|
+        Puppet.debug("get_class_ip_list(): #{v}")
+        ip_list << v
+      }
+    }
+
+    ip_list.sort.reject {|i| i.nil? or i == ''}.uniq
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,12 +3,28 @@ class pf (
   $pfctl          = '/sbin/pfctl',
   $tmpfile        = '/tmp/pf.conf',
   $conf           = '/etc/pf.conf',
+  $pf_d           = '/etc/pf.d',
   $manage_service = $pf::manage_service,
   $service_enable = $pf::service_enable
 ) inherits pf::params {
 
   validate_bool($manage_service)
   validate_bool($service_enable)
+
+  file { $pf_d:
+    ensure  => directory,
+    owner   => 'root',
+    group   => '0',
+    recurse => true,
+    purge   => true,
+  }
+
+  concat { "${pf_d}/tables.pf":
+    owner  => 'root',
+    group  => '0',
+    mode   => '0600',
+    notify => Exec['pfctl_update']
+  }
 
   if $template {
     file { $tmpfile:

--- a/manifests/table.pp
+++ b/manifests/table.pp
@@ -1,0 +1,21 @@
+# Define: pf::table
+#
+#
+define pf::table (
+  $class_list = undef,
+  $ip_list    = undef,
+) {
+
+  include pf
+
+  if $class_list {
+    $class_ip_list = get_class_ip_list($class_list)
+  }
+
+  $final_ip_list = concat($class_ip_list, $ip_list)
+
+  concat::fragment { "/etc/pf.d/tables/${name}.pf":
+    target  => "${pf::pf_d}/tables.pf",
+    content => template('pf/table.erb'),
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -36,5 +36,8 @@
   ],
   "description": "Manage the OpenBSD Packet Filtter with Puppet",
   "dependencies": [
+    {"name":"puppetlabs/concat","version_requirement":">=1.2.1"},
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.0.0" },
+    { "name": "dalen/puppetdbquery", "version_requirement": ">= 1.3.0" }
   ]
 }

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,0 +1,1 @@
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/classes/pf_spec.rb
+++ b/spec/classes/pf_spec.rb
@@ -2,15 +2,26 @@ require 'spec_helper'
 
 describe 'pf' do
   context 'on OpenBSD' do
-    let(:facts) { {:kernel => 'OpenBSD'} }
+    let(:facts) { {
+        :kernel => 'OpenBSD',
+        :concat_basedir => '/dne'
+    } }
     let(:params) { { :template => 'pf/default.erb' } }
     it { should contain_class('pf') }
     it { should_not contain_service('pf') }
 
   end
+  let(:facts) {
+    {
+        :operatingsystem => operatingsystem,
+    }
+  }
 
   context 'on FreeBSD' do
-    let(:facts) { {:kernel => 'FreeBSD'} }
+    let(:facts) { {
+        :kernel => 'FreeBSD',
+        :concat_basedir => '/dne'
+    } }
     let(:params) { { :template => 'pf/default.erb' } }
     it { should contain_class('pf') }
     it { should contain_service('pf') }

--- a/templates/table.erb
+++ b/templates/table.erb
@@ -1,0 +1,5 @@
+table <<%= @name %>> {
+    <% @final_ip_list.sort.each do |i| -%>
+    <%= i %>
+    <% end -%>
+    }


### PR DESCRIPTION
The list of classes passed is used as the argument in a PuppetDB query
to get a list of IPaddresses for nodes that contain the requeste class.
Those IPs are added to the table dynamically.  This feature means tables
can be updated automatically based on node classification and can be
used in the main pf class template.

Future support here will likely include other items to query, and some
restrictions on which address family is being searched.