### PR TITLE
Update default parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,8 +4,8 @@ class pf (
   $tmpfile        = '/tmp/pf.conf',
   $conf           = '/etc/pf.conf',
   $pf_d           = '/etc/pf.d',
-  $manage_service = $pf::manage_service,
-  $service_enable = $pf::service_enable
+  $manage_service = $pf::params::manage_service,
+  $service_enable = $pf::params::service_enable
 ) inherits pf::params {
 
   validate_bool($manage_service)


### PR DESCRIPTION
Currently the pf class' defaults do not work properly due to an invalid
variable reference forcing the user to override the variables to get the
correct functionality.  This work updates the variable in use to refer
to the params class.