### PR TITLE
Move to puppet4, drop support for puppet3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 ---
+sudo: false
 language: ruby
 bundler_args: --without development
-before_install: rm Gemfile.lock || true
+before_install:
+  - rm Gemfile.lock || true
+  - gem update bundler
 rvm:
+  - 1.9.3
   - 2.0.0
   - 2.1.0
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
-sudo: false
+  - PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.1.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.2.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.3.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.4.0" STRICT_VARIABLES=yes

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :test do
   gem "rake"
-  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
+  gem "puppet", ENV['PUPPET_VERSION'] || '~> 4.4.0'
   gem "rspec"
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'rspec-core'

--- a/README.md
+++ b/README.md
@@ -48,33 +48,37 @@ might look like the following.
 pass in on $ext_if proto tcp from $siteA_secondary_ext to $siteA_primary_ext port {isakmp}
 ```
 
-Now this allows you to put the bulk of the code in common templates that can be
-distributed to multiple systems.  This means that in order to make changes to
-the majority of your firewalls, you can do so with just a change to a single
-firewall.  Obviously, how this structure is laid out and the usefulness of
-doing so will be dependent on the environment within which PF is deploy.
+This allows you to put the bulk of the code in common templates that can be
+distributed to multiple systems, which helps reduce the number of files that
+need modifying to make change to a potential large number of systems.  This is
+environment *dependent*.
 
 ### Dynamic tables with PuppetDB
 
-Tables in PF hold groups of addresses for speedy lookup and simplified rulesets.  This combined with PuppetDB queries
- makes for some interesting code.  You can use the `pf::table` defined type to specify a list of classes, who's IP 
- addresses should be in a table.
- 
+Tables in PF hold groups of addresses for speedy lookup and simplified rule
+sets.  This combined with PuppetDB queries makes for some interesting code.
+You can use the `pf::table` defined type to specify a list of classes, who's IP
+addresses should be in a table.
+
 ```Puppet
 pf::table {'ldap_servers':
     class_list => ['profile::ldap::servers'],
 }
 ```
 
-The above code will all a PF table entry to `/etc/pf.d/tables.pf` that you can simply include in your main 
-template with a simple `include "/etc/pf.d/tables.pf`.  Now you can use the `<ldap_servers>` table in your rule set 
-like you would with any other PF table.
+The above code will all a PF table entry to `/etc/pf.d/tables.pf` that you can
+simply include in your main template with a simple `include
+"/etc/pf.d/tables.pf`.  Now you can use the `<ldap_servers>` table in your rule
+set like you would with any other PF table.
 
-This table is populated by querying PuppetDB for all nodes who have the class `profile::ldap::servers` in their 
-catalog, and returning returning the values for `ipaddress` and `ipaddress6` from those nodes, and adding them to the
-table.  This doesn't work for all scenarious, for example, if the IP you want to add to a table is not in either of 
-those facts.
- 
-I'm expecting more to come in this area.
- 
+```pf
+pass in proto { tcp udp } from <local_nets> to <auth_servers> port 88
+pass in proto tcp from <local_nets> to <auth_servers> port { 636 749 }
+```
+
+This table is populated by querying PuppetDB for all nodes who have the class
+`profile::ldap::servers` in their catalog, and returning returning the values
+for `ipaddress` and `ipaddress6` from those nodes, and adding them to the
+  table.  This doesn't work for all scenarios, for example, if the IP you want
+  to add to a table is not in either of those facts.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,14 @@
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet/version'
-require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
+require 'metadata-json-lint/rake_task'
 
-# These gems aren't always present, for instance
+# These two gems aren't always present, for instance
 # on Travis with --without development
 begin
   require 'puppet_blacksmith/rake_tasks'
 rescue LoadError
 end
-
-Rake::Task[:lint].clear
 
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.send("disable_80chars")
@@ -25,7 +22,6 @@ PuppetLint.configuration.send('disable_class_parameter_defaults')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 
 exclude_paths = [
-  "bundle/**/*",
   "pkg/**/*",
   "vendor/**/*",
   "spec/**/*",
@@ -38,19 +34,10 @@ RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'
 end
 
-desc "Populate CONTRIBUTORS file"
-task :contributors do
-  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
-end
-
-task :metadata do
-  sh "metadata-json-lint metadata.json"
-end
-
 desc "Run syntax, lint, and spec tests."
 task :test => [
+  :metadata_lint,
   :syntax,
   :lint,
   :spec,
-  :metadata,
 ]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,15 +1,12 @@
 class pf (
   $template       = undef,
-  $pfctl          = '/sbin/pfctl',
-  $tmpfile        = '/tmp/pf.conf',
-  $conf           = '/etc/pf.conf',
-  $pf_d           = '/etc/pf.d',
-  $manage_service = $pf::params::manage_service,
-  $service_enable = $pf::params::service_enable
+  String $pfctl          = '/sbin/pfctl',
+  String $tmpfile        = '/tmp/pf.conf',
+  String $conf           = '/etc/pf.conf',
+  String $pf_d           = '/etc/pf.d',
+  Boolean $manage_service = $pf::params::manage_service,
+  Boolean $service_enable = $pf::params::service_enable
 ) inherits pf::params {
-
-  validate_bool($manage_service)
-  validate_bool($service_enable)
 
   file { $pf_d:
     ensure  => directory,
@@ -43,14 +40,11 @@ class pf (
     }
 
     if $manage_service {
-      case $service_enable {
-        true: {
-          $service_ensure = 'running'
-        }
-        false: {
-          $service_ensure = 'stopped'
-        }
+      $service_ensure = $service_enable ? {
+        true  => 'running',
+        false => 'stopped',
       }
+
       service { 'pf':
         ensure  => $service_ensure,
         enable  => $service_enable,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,5 +8,8 @@ class pf::params {
       $manage_service = true
       $service_enable = true
     }
+    default: {
+      fail("${::kernel} is not supported")
+    }
   }
 }

--- a/manifests/table.pp
+++ b/manifests/table.pp
@@ -2,8 +2,8 @@
 #
 #
 define pf::table (
-  $class_list = undef,
-  $ip_list    = undef,
+  Array $class_list = [],
+  Array $ip_list    = [],
 ) {
 
   include pf

--- a/metadata.json
+++ b/metadata.json
@@ -11,27 +11,22 @@
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "10.1",
-        "10.0",
-        "9.3",
-        "8.4"
+        "10.3",
+        "9.3"
       ]
     },
     {
       "operatingsystem": "OpenBSD",
       "operatingsystemrelease": [
+        "5.8",
         "5.7"
       ]
     }
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.2.0 < 3.8.0"
-    },
-    {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 4.1.0 < 5.0.0"
     }
   ],
   "description": "Manage the OpenBSD Packet Filtter with Puppet",

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,1 +1,0 @@
-at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/classes/pf_spec.rb
+++ b/spec/classes/pf_spec.rb
@@ -9,6 +9,11 @@ describe 'pf' do
     let(:params) { { :template => 'pf/default.erb' } }
     it { should contain_class('pf') }
     it { should_not contain_service('pf') }
+    it { should contain_file('/etc/pf.conf') }
+    it { should contain_file('/etc/pf.d').with(:ensure=>'directory') }
+    it { should contain_concat('/etc/pf.d/tables.pf') }
+    it { should contain_file('/tmp/pf.conf') }
+    it { should contain_exec('pfctl_update').with(:command=>'/sbin/pfctl -nf /tmp/pf.conf && cp /tmp/pf.conf /etc/pf.conf && /sbin/pfctl -f /etc/pf.conf') }
 
   end
   let(:facts) {
@@ -25,6 +30,11 @@ describe 'pf' do
     let(:params) { { :template => 'pf/default.erb' } }
     it { should contain_class('pf') }
     it { should contain_service('pf') }
+    it { should contain_file('/etc/pf.conf') }
+    it { should contain_file('/etc/pf.d').with(:ensure=>'directory') }
+    it { should contain_concat('/etc/pf.d/tables.pf') }
+    it { should contain_file('/tmp/pf.conf') }
+    it { should contain_exec('pfctl_update').with(:command=>'/sbin/pfctl -nf /tmp/pf.conf && cp /tmp/pf.conf /etc/pf.conf && /sbin/pfctl -f /etc/pf.conf') }
 
   end
 end

--- a/spec/defines/pf_table_spec.rb
+++ b/spec/defines/pf_table_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'pf::table' do
+  context 'on OpenBSD' do
+    let(:facts) { {
+        :kernel => 'OpenBSD',
+        :concat_basedir => '/dne'
+    } }
+    let(:title) { 'web_servers' }
+    it { should contain_concat__fragment('/etc/pf.d/tables/web_servers.pf').with(:content=>/table <web_servers> {/) }
+
+  end
+
+  context 'on FreeBSD' do
+    let(:facts) { {
+        :kernel => 'FreeBSD',
+        :concat_basedir => '/dne'
+    } }
+    let(:title) { 'web_servers' }
+    it { should contain_concat__fragment('/etc/pf.d/tables/web_servers.pf').with(:content=>/table <web_servers> {/) }
+
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,5 @@ RSpec.configure do |c|
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
 end
+
+at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
This work migrates this module to use native language features present
in puppet4 that are not available in puppet3.  This work drops puppet3.x
support and requires puppet4.  Here also are a some updates to the
testing matrix, as well as a few test additions to increase coverage.
