### PR TITLE
Improve flexibility of table population

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,29 @@ for `ipaddress` and `ipaddress6` from those nodes, and adding them to the
   table.  This doesn't work for all scenarios, for example, if the IP you want
   to add to a table is not in either of those facts.
 
+#### More flexible table data using a common class
+
+In the case where a node's `ipaddress` or `ipaddress6` is not the desired value
+to enter a table, this data can be referenced from another class.  Consider the following resources
+
+``` Puppet
+class profile::network::host ($default_address) {}
+
+pf::table {'ldap_servers':
+    class_list         => ['profile::ldap::servers'],
+    common_class       => 'profile::network::host',
+    common_class_param => 'default_address'
+}
+```
+
+In this case, the `profile::network::host::default_address` can be set in
+hiera, on a specific node.  This will cause the `pf::table` resource to first
+look for nodes that have included the `profile::ldap::servers` class, then from
+each of those nodes, look up the value of `default_address` on the
+`profile::network::host` class.  This allows the `default_address` to be
+overridden with something more creative, like an array of facts like
+`[networking.lo1.ip6, networking.lo1.ip4]` or some such.  This comes in quite
+handy when nodes in the environment wish to be referenced by a fact that is not
+the `ipaddress` or `ipaddress6` fact.
+
+

--- a/lib/puppet/parser/functions/get_class_ip_list.rb
+++ b/lib/puppet/parser/functions/get_class_ip_list.rb
@@ -1,14 +1,15 @@
 module Puppet::Parser::Functions
   newfunction(:get_class_ip_list,
-              arity: 1,
+              arity: 2,
               type: :rvalue) do |args|
 
     class_list = args.shift
+    facts_list = args.shift
 
     def self.normalize_class_names(names)
-      Array(names).each do |c|
+      Array(names).map do |c|
         # We need to get the class names in the correct capitalization
-        yield c.split('::').map(&:capitalize).join('::')
+        c.split('::').map(&:capitalize).join('::')
       end
     end
 
@@ -24,7 +25,7 @@ module Puppet::Parser::Functions
     ip_list = []
     normalize_class_names(class_list) do |c|
       query = "Class[#{c}]"
-      facts = %w(ipaddress ipaddress6)
+      facts = facts_list ? facts_list : %w(ipaddress ipaddress6)
       get_fact_values(query, facts) do |v|
         Puppet.debug("get_class_ip_list(): #{v}")
         ip_list << v

--- a/lib/puppet/parser/functions/get_common_class_param_value_list.rb
+++ b/lib/puppet/parser/functions/get_common_class_param_value_list.rb
@@ -1,0 +1,48 @@
+module Puppet::Parser::Functions
+  newfunction(:get_common_class_param_value_list,
+              arity: 3,
+              type: :rvalue) do |args|
+
+    node_class_list    = args.shift
+    common_class       = args.shift
+    common_class_param = args.shift
+
+    def normalize_class_names(names)
+      Array(names).map do |c|
+        # We need to get the class names in the correct capitalization
+        c.split('::').map(&:capitalize).join('::')
+      end
+    end
+
+    def get_class_values(query, node_filter)
+      Puppet.debug("retrieving class values for #{query} filter #{node_filter}")
+      results = function_query_resources([
+        node_filter,
+        query,
+        false
+      ])
+      # The results come back as a single item array, so it looks
+      results.each{|i|
+        yield i['parameters']
+      }
+    end
+
+    ip_list = []
+    # normal_common_class = normalize_class_names(common_class).map.first
+    query = "Class[\"#{common_class}\"]"
+
+    normalize_class_names(node_class_list).each do |c|
+      node_filter = "Class[#{c}]"
+
+      get_class_values(query, node_filter) do |params|
+        Puppet.debug("get_common_class_param_value_list(): #{params}")
+        value = params[common_class_param]
+        Array(value).each do |v|
+          ip_list << v
+        end
+      end
+    end
+
+    ip_list.sort.reject { |i| i.nil? || i == '' }.uniq
+  end
+end

--- a/manifests/table.pp
+++ b/manifests/table.pp
@@ -1,18 +1,51 @@
 # Define: pf::table
 #
+# @param class_list A list of class names for which to lookup hosts and return
+# the fact_list for addresses.
 #
+# @param ip_list A list of IP addresses to include in the table.  These values
+# are always added to the table.
+#
+# @param fact_list Alter the data returned during a class lookup as in the case
+# when using the class_list param.  This is only used if common_class and
+# common_class_param are not used.
+#
+# @param common_class @param common_class_param
+#
+
 define pf::table (
-  Array $class_list = [],
-  Array $ip_list    = [],
+  Array $class_list                    = [],
+  Array $ip_list                       = [],
+  Array $fact_list                     = [],
+  Optional[String] $common_class       = undef,
+  Optional[String] $common_class_param = undef,
 ) {
+
+  # TODO should class_list be called node_filter?  This might make it easier to
+  # filter the nodes that we want, and it looks like a list of classes is still
+  # an appropriate use.  Perhaps a rename here would simply make query results
+  # more powerful, and perhaps more understandable.
 
   include ::pf
 
-  if $class_list {
-    $class_ip_list = get_class_ip_list($class_list)
+   if $class_list.size > 0 {
+    if $common_class and $common_class_param {
+      $class_ip_list = get_common_class_param_value_list(
+        $class_list,
+        $common_class,
+        $common_class_param
+      )
+    } else {
+      if $fact_list {
+        $class_ip_list = get_class_ip_list($class_list, $fact_list)
+      } else {
+        $class_ip_list = get_class_ip_list($class_list)
+      }
+    }
+    $final_ip_list = concat($class_ip_list, $ip_list)
+  } else {
+    $final_ip_list = $ip_list
   }
-
-  $final_ip_list = concat($class_ip_list, $ip_list)
 
   concat::fragment { "/etc/pf.d/tables/${name}.pf":
     target  => "${pf::pf_d}/tables.pf",

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,7 @@
     {
       "operatingsystem": "OpenBSD",
       "operatingsystemrelease": [
+        "6.1",
         "6.0",
         "5.9"
       ]


### PR DESCRIPTION
Here we add logic to allow for querying a common class, and using a parameter
value of the returned class as the value with which to populate a table address.
This allows table population when the IP desired is not the value of the
ipaddress or ipaddress6 fact, allowing each node to override in hiera with the
value on a common class.